### PR TITLE
Update Grok model to grok-3

### DIFF
--- a/server.js
+++ b/server.js
@@ -76,7 +76,7 @@ app.get('/api/dashboard', async (req, res) => {
     const prompt = loadPrompt();
 
     const requestBody = {
-      model: 'grok-beta',
+      model: process.env.GROK_MODEL || 'grok-3',
       messages: [
         {
           role: 'user',


### PR DESCRIPTION
## Summary
- switch the Grok chat completion request to default to the supported `grok-3` model
- allow overriding the model via the `GROK_MODEL` environment variable if needed

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d59c13b160832cb24c422492006834