### PR TITLE
Add ticker selection control to delay dashboard loading

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,13 +16,24 @@
           </p>
         </div>
         <div class="actions">
-          <button id="refreshButton" class="button">Refresh data</button>
-          <button id="downloadButton" class="button button-secondary">Download Full Matrix (Excel)</button>
+          <div class="selection-control">
+            <label for="tickerLimit">Tickers to display</label>
+            <select id="tickerLimit" class="select">
+              <option value="" selected disabled>Select an option</option>
+              <option value="10">First 10</option>
+              <option value="50">First 50</option>
+              <option value="all">All</option>
+            </select>
+          </div>
+          <button id="refreshButton" class="button" disabled>Refresh data</button>
+          <button id="downloadButton" class="button button-secondary" disabled>
+            Download Full Matrix (Excel)
+          </button>
         </div>
       </header>
 
       <section class="status" id="status">
-        <p>Loading dashboard data...</p>
+        <p>Select a ticker range to load the dashboard.</p>
       </section>
 
       <section class="content" id="content">

--- a/public/style.css
+++ b/public/style.css
@@ -57,6 +57,34 @@ body {
 .actions {
   display: flex;
   gap: 0.75rem;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.selection-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.selection-control label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.select {
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text-primary);
+  padding: 0.65rem 1rem;
+  font-size: 1rem;
+  min-width: 160px;
+}
+
+.select:focus {
+  outline: 2px solid rgba(56, 189, 248, 0.55);
+  outline-offset: 2px;
 }
 
 .button {
@@ -165,6 +193,10 @@ body {
   .status,
   .content {
     padding: 1.25rem;
+  }
+
+  .actions {
+    align-items: stretch;
   }
 
   .button {


### PR DESCRIPTION
## Summary
- add a ticker selection control to the dashboard header and tweak layout styles to accommodate it
- defer dashboard loading until the user picks a ticker limit and trim the rendered table to the chosen size
- keep refresh and download actions disabled until data has loaded for the selected range

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d5b380f6e0832c92e50fc222b36fa7