### PR TITLE
Add download for full normalized dataset

### DIFF
--- a/database.js
+++ b/database.js
@@ -212,10 +212,33 @@ class DatabaseManager {
     });
   }
 
+  // Get the complete kpi_with_normalization dataset
+  async getFullNormalizedDataset(date = null) {
+    let sql = 'SELECT * FROM kpi_with_normalization';
+    const params = [];
+
+    if (date) {
+      sql += ' WHERE fetch_date = ?';
+      params.push(date);
+    }
+
+    sql += ' ORDER BY fetch_time DESC';
+
+    return new Promise((resolve, reject) => {
+      this.db.all(sql, params, (err, rows) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(rows);
+        }
+      });
+    });
+  }
+
   // Get top performers by overall score
   async getTopPerformers(limit = 10, date = null) {
     let sql = `
-      SELECT ticker, company_name, overall_score, momentum_score, trend_score, 
+      SELECT ticker, company_name, overall_score, momentum_score, trend_score,
              volatility_score, strength_score, support_resistance_score, fetch_time
       FROM kpi_with_normalization 
       WHERE overall_score IS NOT NULL

--- a/normalizationIntegration.js
+++ b/normalizationIntegration.js
@@ -123,6 +123,22 @@ class NormalizationIntegration {
   }
 
   /**
+   * Retrieve the complete normalized dataset (raw + normalized columns)
+   */
+  async getFullNormalizedDataset(date = null) {
+    if (!this.isInitialized) {
+      await this.initialize();
+    }
+
+    try {
+      return await this.db.getFullNormalizedDataset(date);
+    } catch (error) {
+      console.error('Error retrieving full normalized dataset:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Get top performing tickers based on overall score
    */
   async getTopPerformers(limit = 10, date = null) {

--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,9 @@
           <button id="downloadButton" class="button button-secondary" disabled>
             Download Full Matrix (Excel)
           </button>
+          <button id="downloadDatasetButton" class="button button-secondary" disabled>
+            Download Normalized Dataset (Excel)
+          </button>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- add database and integration helpers to retrieve the complete `kpi_with_normalization` dataset
- expose an API route that streams the full normalized dataset as an Excel workbook
- surface a frontend button to download the dataset and align UI state handling

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d60d22c284832cbf70fd90e823c92c