### PR TITLE
Add ticker formula export option to dashboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,9 @@
           <button id="downloadButton" class="button button-secondary" disabled>
             Download Full Matrix (Excel)
           </button>
+          <button id="downloadTickerFormulaButton" class="button button-secondary" disabled>
+            Download Matrix with Ticker Links (Excel)
+          </button>
           <button id="downloadDatasetButton" class="button button-secondary" disabled>
             Download Normalized Dataset (Excel)
           </button>


### PR DESCRIPTION
## Summary
- add a dashboard control to download the matrix with ticker hyperlink formulas
- enhance the Excel export builder to inject hyperlink formulas using the ticker URL dataset
- expose a new API endpoint that serves the matrix with ticker formulas for the selected ticker range

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d69b0e13b8832cb88a9ecc89661eaf