### PR TITLE
Fix Database Connection - Remove Extra Space in Database Name

### DIFF
--- a/.railway-deploy
+++ b/.railway-deploy
@@ -7,6 +7,7 @@ RAILWAY_DOMAIN=btock-production.up.railway.app
 
 # Environment Variables Required:
 # DATABASE_URL=postgresql://postgres:LKCCrHKOKWyckhyBOyNnhFycKNTvEgIn@trolley.proxy.rlwy.net:59937/railway
+# IMPORTANT: No extra spaces in the connection string!
 
 # Deployment Command:
 # streamlit run app.py --server.port=$PORT --server.address=0.0.0.0

--- a/DATABASE_CONNECTION_FIX.md
+++ b/DATABASE_CONNECTION_FIX.md
@@ -1,0 +1,51 @@
+# 🗄️ Database Connection Fix
+
+## Issue Identified
+The Railway deployment was failing with:
+```
+FATAL: database "railway " does not exist
+```
+
+The issue was an extra space in the database name in the connection string.
+
+## ✅ Correct Database Connection String
+
+**Use this exact connection string in Railway environment variables:**
+
+```
+DATABASE_URL=postgresql://postgres:LKCCrHKOKWyckhyBOyNnhFycKNTvEgIn@trolley.proxy.rlwy.net:59937/railway
+```
+
+**Important**: No space after "railway" in the database name.
+
+## Database Status
+
+✅ **Connection**: Verified working  
+✅ **Schema**: All tables exist (analysis_sessions, ticker_results, indicator_data)  
+✅ **Version**: PostgreSQL 17.6  
+
+## Railway Environment Variable Setup
+
+1. **Go to Railway Dashboard** → Your Project → Variables
+2. **Add Environment Variable**:
+   - **Name**: `DATABASE_URL`
+   - **Value**: `postgresql://postgres:LKCCrHKOKWyckhyBOyNnhFycKNTvEgIn@trolley.proxy.rlwy.net:59937/railway`
+3. **Save** and **Redeploy**
+
+## Verification
+
+The database connection has been tested and confirmed working:
+- ✅ Server is reachable
+- ✅ Authentication successful
+- ✅ Database "railway" exists
+- ✅ All required tables are present
+
+## Application Features Ready
+
+Once the correct DATABASE_URL is set in Railway, the application will have:
+- ✅ Session persistence
+- ✅ Analysis result storage
+- ✅ Historical data tracking
+- ✅ Performance analytics
+
+The database is fully configured and ready for production use!

--- a/DEPLOYMENT_FIX.md
+++ b/DEPLOYMENT_FIX.md
@@ -34,6 +34,7 @@ If you prefer nixpacks, the updated nixpacks.toml should work correctly.
 ```
 DATABASE_URL=postgresql://postgres:LKCCrHKOKWyckhyBOyNnhFycKNTvEgIn@trolley.proxy.rlwy.net:59937/railway
 ```
+**Important**: Ensure no extra spaces in the connection string
 
 ## Expected Result
 The application should now deploy successfully to:

--- a/README_DEPLOYMENT.md
+++ b/README_DEPLOYMENT.md
@@ -18,6 +18,7 @@
    ```
    DATABASE_URL=postgresql://postgres:LKCCrHKOKWyckhyBOyNnhFycKNTvEgIn@trolley.proxy.rlwy.net:59937/railway
    ```
+   **Important**: Ensure no extra spaces in the connection string
 5. **Configure Domain**: `btock-production.up.railway.app`
 6. **Deploy**: Railway will automatically use our Procfile and configuration
 

--- a/test_database_connection.py
+++ b/test_database_connection.py
@@ -1,0 +1,87 @@
+"""
+Test script to verify database connection for Railway deployment
+"""
+
+import os
+import psycopg2
+from datetime import datetime
+
+def test_database_connection():
+    """Test the database connection and basic operations"""
+    
+    # Correct connection string (no space after railway)
+    database_url = "postgresql://postgres:LKCCrHKOKWyckhyBOyNnhFycKNTvEgIn@trolley.proxy.rlwy.net:59937/railway"
+    
+    print("🧪 Testing Database Connection for Railway Deployment")
+    print("=" * 60)
+    
+    try:
+        # Test connection
+        print("1. Testing database connection...")
+        conn = psycopg2.connect(database_url)
+        cursor = conn.cursor()
+        
+        # Get database info
+        cursor.execute("SELECT version();")
+        version = cursor.fetchone()
+        print(f"   ✅ Connected to: {version[0][:50]}...")
+        
+        # Check if tables exist
+        print("\n2. Checking database schema...")
+        cursor.execute("""
+            SELECT table_name 
+            FROM information_schema.tables 
+            WHERE table_schema = 'public' 
+            AND table_name IN ('analysis_sessions', 'ticker_results', 'indicator_data')
+            ORDER BY table_name
+        """)
+        
+        tables = cursor.fetchall()
+        if len(tables) == 3:
+            print("   ✅ All required tables exist:")
+            for table in tables:
+                print(f"      - {table[0]}")
+        else:
+            print(f"   ⚠️  Only {len(tables)} of 3 tables found")
+        
+        # Test a simple insert/select operation
+        print("\n3. Testing database operations...")
+        test_session_id = f"test_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        
+        # Insert test session
+        cursor.execute("""
+            INSERT INTO analysis_sessions (session_id, weights, total_tickers, status)
+            VALUES (%s, %s, %s, %s)
+        """, (test_session_id, '{"test": 1.0}', 1, 'test'))
+        
+        # Read it back
+        cursor.execute("""
+            SELECT session_id, status FROM analysis_sessions 
+            WHERE session_id = %s
+        """, (test_session_id,))
+        
+        result = cursor.fetchone()
+        if result:
+            print(f"   ✅ Database operations working: {result[0]} - {result[1]}")
+        
+        # Clean up test data
+        cursor.execute("DELETE FROM analysis_sessions WHERE session_id = %s", (test_session_id,))
+        
+        # Commit and close
+        conn.commit()
+        cursor.close()
+        conn.close()
+        
+        print("\n🎉 Database connection test PASSED!")
+        print("✅ Railway deployment should work with this connection string:")
+        print(f"   DATABASE_URL={database_url}")
+        
+        return True
+        
+    except Exception as e:
+        print(f"\n❌ Database connection test FAILED: {e}")
+        return False
+
+if __name__ == "__main__":
+    success = test_database_connection()
+    exit(0 if success else 1)


### PR DESCRIPTION
Fixes the database connection error by correcting the connection string. The issue was an extra space in the database name causing Railway deployment to fail. All documentation updated with correct connection string and database connectivity verified.