### PR TITLE
Document Reddit credentials and secure client setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ XAI_API_KEY=your_grok_api_key
 XAI_API_URL=https://api.x.ai/v1/chat/completions
 REDDIT_CLIENT_ID=your_reddit_client_id
 REDDIT_CLIENT_SECRET=your_reddit_client_secret
+REDDIT_USERNAME=your_reddit_username
+REDDIT_PASSWORD=your_reddit_password
 REDDIT_USER_AGENT=Btock Sentiment Analyzer v1.0
 ```
 
@@ -179,6 +181,8 @@ export DATABASE_URL="postgresql://..."
 export XAI_API_KEY="your_key"
 export REDDIT_CLIENT_ID="your_id"
 export REDDIT_CLIENT_SECRET="your_secret"
+export REDDIT_USERNAME="your_username"
+export REDDIT_PASSWORD="your_password"
 
 # Run application
 streamlit run app.py

--- a/SENTIMENT_TROUBLESHOOTING.md
+++ b/SENTIMENT_TROUBLESHOOTING.md
@@ -14,7 +14,7 @@ This guide helps you configure and troubleshoot the sentiment analysis feature t
 ### **Step 2: Identify Required APIs**
 The sentiment analysis uses three data sources:
 - **X (Twitter)** via Grok API - Requires XAI_API_KEY
-- **Reddit** - Requires REDDIT_CLIENT_ID and REDDIT_CLIENT_SECRET  
+- **Reddit** - Requires REDDIT_CLIENT_ID, REDDIT_CLIENT_SECRET, REDDIT_USERNAME, and REDDIT_PASSWORD
 - **StockTwits** - Public API (no key required, but may have rate limits)
 
 ## 🔑 API Configuration Steps
@@ -56,6 +56,8 @@ XAI_API_URL=https://api.grok.x.ai/v1/chat/completions
 # In Railway Dashboard → Variables
 REDDIT_CLIENT_ID=your_reddit_client_id
 REDDIT_CLIENT_SECRET=your_reddit_client_secret
+REDDIT_USERNAME=your_reddit_username
+REDDIT_PASSWORD=your_reddit_password
 REDDIT_USER_AGENT=Btock Sentiment Analyzer v1.0
 ```
 
@@ -80,6 +82,8 @@ REDDIT_USER_AGENT=Btock Sentiment Analyzer v1.0
    XAI_API_KEY=your_key
    REDDIT_CLIENT_ID=your_id
    REDDIT_CLIENT_SECRET=your_secret
+   REDDIT_USERNAME=your_username
+   REDDIT_PASSWORD=your_password
    ```
 
 2. **Restart Application**
@@ -131,7 +135,9 @@ REDDIT_USER_AGENT=Btock Sentiment Analyzer v1.0
    import praw
    reddit = praw.Reddit(
        client_id="your_client_id",
-       client_secret="your_client_secret", 
+       client_secret="your_client_secret",
+       username="your_username",
+       password="your_password",
        user_agent="test"
    )
    print(list(reddit.subreddit("test").hot(limit=1)))

--- a/modules/sentiment_analyzer.py
+++ b/modules/sentiment_analyzer.py
@@ -31,13 +31,29 @@ class SentimentAnalyzer:
             
             # Reddit API setup
             self.reddit = None
-            if all([os.getenv("REDDIT_CLIENT_ID"), os.getenv("REDDIT_CLIENT_SECRET")]):
+            reddit_credentials = {
+                "REDDIT_CLIENT_ID": os.getenv("REDDIT_CLIENT_ID"),
+                "REDDIT_CLIENT_SECRET": os.getenv("REDDIT_CLIENT_SECRET"),
+                "REDDIT_USERNAME": os.getenv("REDDIT_USERNAME"),
+                "REDDIT_PASSWORD": os.getenv("REDDIT_PASSWORD"),
+            }
+            missing_credentials = [name for name, value in reddit_credentials.items() if not value]
+
+            if missing_credentials:
+                st.warning(
+                    "Reddit API setup failed: Missing credentials - "
+                    + ", ".join(missing_credentials)
+                )
+            else:
                 try:
                     self.reddit = praw.Reddit(
-                        client_id=os.getenv("REDDIT_CLIENT_ID"),
-                        client_secret=os.getenv("REDDIT_CLIENT_SECRET"),
+                        client_id=reddit_credentials["REDDIT_CLIENT_ID"],
+                        client_secret=reddit_credentials["REDDIT_CLIENT_SECRET"],
+                        username=reddit_credentials["REDDIT_USERNAME"],
+                        password=reddit_credentials["REDDIT_PASSWORD"],
                         user_agent=os.getenv("REDDIT_USER_AGENT", "Btock Sentiment Analyzer v1.0")
                     )
+                    self.reddit.read_only = True
                     # Test Reddit connection
                     list(self.reddit.subreddit("test").hot(limit=1))
                 except Exception as e:

--- a/modules/sentiment_analyzer_clean.py
+++ b/modules/sentiment_analyzer_clean.py
@@ -32,14 +32,31 @@ class SentimentAnalyzer:
             
             # Reddit API setup
             self.reddit = None
-            if all([os.getenv("REDDIT_CLIENT_ID"), os.getenv("REDDIT_CLIENT_SECRET")]):
+            reddit_credentials = {
+                "REDDIT_CLIENT_ID": os.getenv("REDDIT_CLIENT_ID"),
+                "REDDIT_CLIENT_SECRET": os.getenv("REDDIT_CLIENT_SECRET"),
+                "REDDIT_USERNAME": os.getenv("REDDIT_USERNAME"),
+                "REDDIT_PASSWORD": os.getenv("REDDIT_PASSWORD"),
+            }
+            missing_credentials = [name for name, value in reddit_credentials.items() if not value]
+
+            if missing_credentials:
+                st.warning(
+                    "Reddit API setup failed: Missing credentials - "
+                    + ", ".join(missing_credentials)
+                )
+            else:
                 try:
                     self.reddit = praw.Reddit(
-                        client_id=os.getenv("REDDIT_CLIENT_ID"),
-                        client_secret=os.getenv("REDDIT_CLIENT_SECRET"),
+                        client_id=reddit_credentials["REDDIT_CLIENT_ID"],
+                        client_secret=reddit_credentials["REDDIT_CLIENT_SECRET"],
+                        username=reddit_credentials["REDDIT_USERNAME"],
+                        password=reddit_credentials["REDDIT_PASSWORD"],
                         user_agent=os.getenv("REDDIT_USER_AGENT", "Btock Sentiment Analyzer v1.0")
                     )
+                    self.reddit.read_only = True
                 except Exception as e:
+                    st.warning(f"Reddit API setup failed: {str(e)}")
                     self.reddit = None
             
             # StockTwits API (public, no key required)

--- a/modules/sentiment_analyzer_fixed.py
+++ b/modules/sentiment_analyzer_fixed.py
@@ -32,13 +32,29 @@ class SentimentAnalyzer:
             
             # Reddit API setup
             self.reddit = None
-            if all([os.getenv("REDDIT_CLIENT_ID"), os.getenv("REDDIT_CLIENT_SECRET")]):
+            reddit_credentials = {
+                "REDDIT_CLIENT_ID": os.getenv("REDDIT_CLIENT_ID"),
+                "REDDIT_CLIENT_SECRET": os.getenv("REDDIT_CLIENT_SECRET"),
+                "REDDIT_USERNAME": os.getenv("REDDIT_USERNAME"),
+                "REDDIT_PASSWORD": os.getenv("REDDIT_PASSWORD"),
+            }
+            missing_credentials = [name for name, value in reddit_credentials.items() if not value]
+
+            if missing_credentials:
+                st.warning(
+                    "Reddit API setup failed: Missing credentials - "
+                    + ", ".join(missing_credentials)
+                )
+            else:
                 try:
                     self.reddit = praw.Reddit(
-                        client_id=os.getenv("REDDIT_CLIENT_ID"),
-                        client_secret=os.getenv("REDDIT_CLIENT_SECRET"),
+                        client_id=reddit_credentials["REDDIT_CLIENT_ID"],
+                        client_secret=reddit_credentials["REDDIT_CLIENT_SECRET"],
+                        username=reddit_credentials["REDDIT_USERNAME"],
+                        password=reddit_credentials["REDDIT_PASSWORD"],
                         user_agent=os.getenv("REDDIT_USER_AGENT", "Btock Sentiment Analyzer v1.0")
                     )
+                    self.reddit.read_only = True
                 except Exception as e:
                     st.warning(f"Reddit API setup failed: {str(e)}")
             

--- a/modules/sentiment_analyzer_production.py
+++ b/modules/sentiment_analyzer_production.py
@@ -31,13 +31,29 @@ class SentimentAnalyzer:
             
             # Reddit API setup
             self.reddit = None
-            if all([os.getenv("REDDIT_CLIENT_ID"), os.getenv("REDDIT_CLIENT_SECRET")]):
+            reddit_credentials = {
+                "REDDIT_CLIENT_ID": os.getenv("REDDIT_CLIENT_ID"),
+                "REDDIT_CLIENT_SECRET": os.getenv("REDDIT_CLIENT_SECRET"),
+                "REDDIT_USERNAME": os.getenv("REDDIT_USERNAME"),
+                "REDDIT_PASSWORD": os.getenv("REDDIT_PASSWORD"),
+            }
+            missing_credentials = [name for name, value in reddit_credentials.items() if not value]
+
+            if missing_credentials:
+                st.warning(
+                    "Reddit API setup failed: Missing credentials - "
+                    + ", ".join(missing_credentials)
+                )
+            else:
                 try:
                     self.reddit = praw.Reddit(
-                        client_id=os.getenv("REDDIT_CLIENT_ID"),
-                        client_secret=os.getenv("REDDIT_CLIENT_SECRET"),
+                        client_id=reddit_credentials["REDDIT_CLIENT_ID"],
+                        client_secret=reddit_credentials["REDDIT_CLIENT_SECRET"],
+                        username=reddit_credentials["REDDIT_USERNAME"],
+                        password=reddit_credentials["REDDIT_PASSWORD"],
                         user_agent=os.getenv("REDDIT_USER_AGENT", "Btock Sentiment Analyzer v1.0")
                     )
+                    self.reddit.read_only = True
                     # Test Reddit connection
                     list(self.reddit.subreddit("test").hot(limit=1))
                 except Exception as e:


### PR DESCRIPTION
## Summary
- require full Reddit script credentials in all sentiment analyzer modules and set clients to read-only mode
- warn explicitly when individual Reddit credentials are missing during setup
- document the new REDDIT_USERNAME and REDDIT_PASSWORD variables in the README and troubleshooting guide

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7152ac608832c8c41bfaea8901e27