### PR TITLE
🚨 URGENT FIX: Resolve KeyError final_score

### DIFF
--- a/app.py
+++ b/app.py
@@ -401,11 +401,11 @@ def main():
             # Count signals
             signal_counts = results_df['signal'].value_counts().to_dict()
             total_tickers = len(results_df)
-            avg_score = results_df['final_score'].mean()
+            avg_score = results_df['final_weighted_score'].mean()
             
             # Calculate score range
-            min_score = results_df['final_score'].min()
-            max_score = results_df['final_score'].max()
+            min_score = results_df['final_weighted_score'].min()
+            max_score = results_df['final_weighted_score'].max()
             score_range = f"{min_score:.4f} to {max_score:.4f}"
             
             # Create enhanced summary


### PR DESCRIPTION
Fixes the KeyError by using the correct column name 'final_weighted_score' instead of 'final_score'. Minimal change - only corrected 3 lines to use the actual column name returned by the scoring engine.