### PR TITLE
Update default scoring weights

### DIFF
--- a/modules/scoring.py
+++ b/modules/scoring.py
@@ -14,11 +14,11 @@ class ScoringEngine:
     
     def __init__(self):
         self.category_weights = {
-            'momentum': 0.2,
-            'trend': 0.3,
-            'volatility': 0.15,
-            'strength': 0.2,
-            'support_resistance': 0.15
+            'momentum': 0.30,
+            'trend': 0.40,
+            'volatility': 0.05,
+            'strength': 0.05,
+            'support_resistance': 0.20
         }
         
         # Thresholds for BUY/HOLD/SELL signals

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -222,11 +222,11 @@ class WeightValidator:
     def get_default_weights() -> Dict[str, float]:
         """Get default category weights"""
         return {
-            'momentum': 0.2,
-            'trend': 0.3,
-            'volatility': 0.15,
-            'strength': 0.2,
-            'support_resistance': 0.15
+            'momentum': 0.30,
+            'trend': 0.40,
+            'volatility': 0.05,
+            'strength': 0.05,
+            'support_resistance': 0.20
         }
 
 


### PR DESCRIPTION
## Summary
- update the default weight configuration to use the new standard ratios for each analysis category
- align the scoring engine's built-in weights with the updated defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7602fcdcc832c969ffd0dec1cf1c1